### PR TITLE
Allow skipping the templating

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -22,15 +22,17 @@ procs=$(cat /proc/cpuinfo |grep processor | wc -l)
 sed -i -e "s/worker_processes 5/worker_processes $procs/" /etc/nginx/nginx.conf
 
 # Very dirty hack to replace variables in code with ENVIRONMENT values
-
-for i in $(env)
-do
-  variable=$(echo "$i" | cut -d'=' -f1)
-  value=$(echo "$i" | cut -d'=' -f2)
-  if [[ "$variable" != '%s' ]] ; then
-    replace='\$\$_'${variable}'_\$\$'
-    find /usr/share/nginx/html -type f -exec sed -i -e 's/'${replace}'/'${value}'/g' {} \; ; fi
+if [[ "$TEMPLATE_NGINX_HTML" != "0" ]] ; then
+  for i in $(env)
+  do
+    variable=$(echo "$i" | cut -d'=' -f1)
+    value=$(echo "$i" | cut -d'=' -f2)
+    if [[ "$variable" != '%s' ]] ; then
+      replace='\$\$_'${variable}'_\$\$'
+      find /usr/share/nginx/html -type f -exec sed -i -e 's/'${replace}'/'${value}'/g' {} \;
+    fi
   done
+fi
 
 # Start supervisord and services
 /usr/local/bin/supervisord -n

--- a/start.sh
+++ b/start.sh
@@ -2,6 +2,7 @@
 
 # Disable Strict Host checking for non interactive git clones
 
+mkdir -p -m 0700 /root/.ssh
 echo -e "Host *\n\tStrictHostKeyChecking no\n" >> /root/.ssh/config
 
 # Pull down code form git for our site!


### PR DESCRIPTION
When you have a large code base, the templating can take some time. This allows you to skip it if you have no interest in it.

Maybe a more sane default would be to disable it unless explicitly activated, but that would be backwards incompatible.

It also ensures /root/.ssh exists before trying to append to /root/.ssh/config.