### PR TITLE
Supervisord pass through stdout and stderr from children

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -26,12 +26,20 @@ command=/usr/sbin/php5-fpm -c /etc/php5/fpm
 autostart=true
 autorestart=true
 priority=5
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [program:nginx]
 command=/usr/sbin/nginx
 autostart=true
 autorestart=true
 priority=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 stdout_events_enabled=true
 stderr_events_enabled=true
 


### PR DESCRIPTION
Could also consider linking /var/log/nginx/access.log and error.log to stdout and stderr like the nginx official container [does](https://github.com/nginxinc/docker-nginx/blob/a8b6da8425c4a41a5dedb1fb52e429232a55ad41/Dockerfile#L14-L16) for standard configs.