### PR TITLE
Better verify of permissions

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -43,5 +43,8 @@ if [[ "$TEMPLATE_NGINX_HTML" != "0" ]] ; then
   done
 fi
 
+# Again set the right permissions (needed when mounting from a volume)
+chown -Rf www-data.www-data /usr/share/nginx/html/
+
 # Start supervisord and services
 /usr/bin/supervisord -n -c /etc/supervisord.conf


### PR DESCRIPTION
I had a problem with your docker, when I mounted my web files from a docker volume container. The rights were still set to the owner root:root.


With this little fix they should be set properly to the runtime!


Cheers,
Michael