### PR TITLE
Do not change user of files unless requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ In order to speed up boot time templating is now diabled by default, if you wish
 ### Template anything
 Yes ***ANYTHING***, any variable exposed by a linked container or the **-e** flag lets you template your configuration files. This means you can add redis, mariaDB, memcache or anything you want to your application very easily.
 
+### Changing the owner of the website files at startup
+The container has
+[a startup script](https://github.com/ngineered/nginx-php-fpm/blob/master/scripts/start.sh)
+which, by default, changes only the group of the website files to `www-data`,
+and leaves the user of these files alone. This way, in a
+development environment, in which you are probably mounting the
+website files as a volume, you can still save the files.
+
+For any other environment, you should determine the owner of the files, too,
+by setting this environment variable when running the container:
+
+```
+-e SET_USER=www-data
+```
+
 ## Logging and Errors
 
 ### Logging

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 ## Introduction
 This is a Dockerfile to build a container image for nginx and php-fpm, with the ability to pull website code from git. The container can also use environment variables to configure your web application using the templating detailed in the special features section.
+
 ### Git repository
 The source files for this project can be found here: [https://github.com/ngineered/nginx-php-fpm](https://github.com/ngineered/nginx-php-fpm)
 
 If you have any improvements please submit a pull request.
+
 ### Docker hub repository
 The Docker hub build can be found here: [https://registry.hub.docker.com/u/richarvey/nginx-php-fpm/](https://registry.hub.docker.com/u/richarvey/nginx-php-fpm/)
+
 ## Versions
 
 | Tag    | nginx  | PHP               | Ubuntu  |
@@ -20,22 +23,26 @@ To build from source you need to clone the git repo and run docker build:
 git clone https://github.com/ngineered/nginx-php-fpm.git
 docker build -t richarvey/nginx-php-fpm:latest .
 ```
+
 ## Pulling from Docker Hub
 Pull the image from docker hub rather than downloading the git repo. This prevents you having to build the image on every docker host:
 ```
 docker pull richarvey/nginx-php-fpm:latest
 ```
+
 ## Running
 To simply run the container:
 ```
 sudo docker run --name nginx -p 8080:80 -d richarvey/nginx-php-fpm
 ```
 You can then browse to ```http://<DOCKER_HOST>:8080``` to view the default install files.
+
 ### Volumes
 If you want to link to your web site directory on the docker host to the container run:
 ```
 sudo docker run --name nginx -p 8080:80 -v /your_code_directory:/usr/share/nginx/html -d richarvey/nginx-php-fpm
 ```
+
 ### Dynamically Pulling code from git
 One of the nice features of this container is its ability to pull code from a git repository with a couple of environmental variables passed at run time.
 
@@ -49,6 +56,7 @@ To pull a repository and specify a branch add the GIT_BRANCH environment variabl
 ```
 sudo docker run -e 'GIT_REPO=git@git.ngd.io:ngineered/ngineered-website.git' -e 'GIT_BRANCH=stage' -v /opt/ngddeploy/:/root/.ssh -p 8080:80 -d richarvey/nginx-php-fpm
 ```
+
 ### Linking
 Linking to containers also exposes the linked container environment variables which is useful for templating and configuring web apps.
 
@@ -75,6 +83,7 @@ To link the container launch like this:
 ```
 sudo docker run -e 'GIT_REPO=git@git.ngd.io:ngineered/ngineered-website.git' -v /opt/ngddeploy/:/root/.ssh -p 8080:80 --link some-mysql:mysql -d richarvey/nginx-php-fpm
 ```
+
 ### Enabling SSL or Special Nginx Configs
 As with all docker containers its possible to link resources from the host OS to the guest. This makes it really easy to link in custom nginx default config files or extra virtual hosts and SSL enabled sites. For SSL sites first create a directory somewhere such as */opt/deployname/ssl/*. In this directory drop you SSL cert and Key in. Next create a directory for your custom hosts such as  */opt/deployname/sites-enabled*. In here load your custom default.conf file which references your SSL cert and keys at the location, for example:  */etc/nginx/ssl/xxxx.key*
 
@@ -82,6 +91,7 @@ Then start your container and connect these volumes like so:
 ```
 sudo docker run -e 'GIT_REPO=git@git.ngd.io:ngineered/ngineered-website.git' -v /opt/ngddeploy/:/root/.ssh -v /opt/deployname/ssl:/etc/nginx/ssl -v /opt/deployname/sites-enabled:/etc/nginx/sites-enabled -p 8080:80 --link some-mysql:mysql -d richarvey/nginx-php-fpm
 ```
+
 ## Special Features
 
 ### Push code to Git
@@ -89,16 +99,19 @@ To push code changes back to git simply run:
 ```
 sudo docker exec -t -i <CONATINER_NAME> /usr/bin/push
 ```
+
 ### Pull code from Git (Refresh)
 In order to refresh the code in a container and pull newer code form git simply run:
 ```
 sudo docker exec -t -i <CONTAINER_NAME> /usr/bin/pull
 ```
+
 ### Install Extra Modules
 If you wish to install extras at boot time, such as extra php modules you can specify this by adding the DEBS flag, to add multiple packages you need to space separate the values:
 ```
 sudo docker run --name nginx -e 'DEBS=php5-mongo php-json" -p 8080:80 -d richarvey/nginx-php-fpm
 ```
+
 ### Templating
 This container will automatically configure your web application if you template your code. For example if you are linking to MySQL like above, and you have a config.php file where you need to set the MySQL details include $$_MYSQL_ENV_MYSQL_DATABASE_$$ style template tags.
 
@@ -110,6 +123,7 @@ database_host = $$_MYSQL_PORT_3306_TCP_ADDR_$$;
 ...
 ?>
 ```
+
 ### Using environment variables
 If you want to link to an external MySQL DB and not using linking you can pass variables directly to the container that will be automatically configured by the container.
 
@@ -133,11 +147,13 @@ database_pass = $$_MYSQL_PASS_$$
 ...
 ?>
 ```
+
 ### Enable Templating
 In order to speed up boot time templating is now diabled by default, if you wish to enable it simply include the flag below:
 ```
 -e TEMPLATE_NGINX_HTML=1
 ```
+
 ### Template anything
 Yes ***ANYTHING***, any variable exposed by a linked container or the **-e** flag lets you template your configuration files. This means you can add redis, mariaDB, memcache or anything you want to your application very easily.
 
@@ -148,6 +164,7 @@ All logs should now print out in stdout/stderr and are available via the docker 
 ```
 docker logs <CONTAINER_NAME>
 ```
+
 ### Displaying Errors
 If you want to display PHP errors on screen (in the browser) for debugging purposes use this feature:
 ```

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -57,8 +57,14 @@ if [[ "$TEMPLATE_NGINX_HTML" == "1" ]] ; then
   done
 fi
 
-# Set owner of files (needed when mounting from a volume)
-chown -Rf www-data.www-data $PATH_HTML
+# Set user and group of website files (needed when mounting from a volume)
+if [ -z "$SET_USER" ]; then
+  # In production it is recommended to:  -e SET_USER=www-data
+  chown -Rf $SET_USER.www-data $PATH_HTML
+else
+  # In development you keep your user and we set the group only
+  chgrp -Rf www-data $PATH_HTML
+fi
 
 # Start supervisord and the services configured therein
 /usr/bin/supervisord -n -c /etc/supervisord.conf

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Define some constants that are reused in this script
+PATH_NGINX=/usr/share/nginx
+PATH_HTML=$PATH_NGINX/html/
+
 # Disable Strict Host checking for non interactive git clones
 mkdir -p -m 0700 /root/.ssh
 echo -e "Host *\n\tStrictHostKeyChecking no\n" >> /root/.ssh/config
@@ -23,11 +27,11 @@ fi
 if [ ! -z "$GIT_REPO" ]; then
   rm /usr/share/nginx/html/*
   if [ ! -z "$GIT_BRANCH" ]; then
-    git clone -b $GIT_BRANCH $GIT_REPO /usr/share/nginx/html/
+    git clone -b $GIT_BRANCH $GIT_REPO $PATH_HTML
   else
-    git clone $GIT_REPO /usr/share/nginx/html/
+    git clone $GIT_REPO $PATH_HTML
   fi
-  chown -Rf nginx.nginx /usr/share/nginx/*
+  chown -Rf nginx.nginx $PATH_NGINX/*
 fi
 
 # Display PHP errors or not
@@ -54,7 +58,7 @@ if [[ "$TEMPLATE_NGINX_HTML" == "1" ]] ; then
 fi
 
 # Set owner of files (needed when mounting from a volume)
-chown -Rf www-data.www-data /usr/share/nginx/html/
+chown -Rf www-data.www-data $PATH_HTML
 
 # Start supervisord and the services configured therein
 /usr/bin/supervisord -n -c /etc/supervisord.conf

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
 # Disable Strict Host checking for non interactive git clones
-
 mkdir -p -m 0700 /root/.ssh
 echo -e "Host *\n\tStrictHostKeyChecking no\n" >> /root/.ssh/config
 
-# Setup git variables
+# Set up git variables
 if [ ! -z "$GIT_EMAIL" ]; then
  git config --global user.email "$GIT_EMAIL"
 fi
@@ -14,13 +13,13 @@ if [ ! -z "$GIT_NAME" ]; then
  git config --global push.default simple
 fi
 
-# Install Extras
+# Install extras
 if [ ! -z "$DEBS" ]; then
  apt-get update
  apt-get install -y $DEBS
 fi
 
-# Pull down code form git for our site!
+# Pull down code from git for our site!
 if [ ! -z "$GIT_REPO" ]; then
   rm /usr/share/nginx/html/*
   if [ ! -z "$GIT_BRANCH" ]; then
@@ -31,14 +30,13 @@ if [ ! -z "$GIT_REPO" ]; then
   chown -Rf nginx.nginx /usr/share/nginx/*
 fi
 
-# Display PHP error's or not
+# Display PHP errors or not
 if [[ "$ERRORS" != "1" ]] ; then
   sed -i -e "s/error_reporting =.*=/error_reporting = E_ALL/g" /etc/php5/fpm/php.ini
   sed -i -e "s/display_errors =.*/display_errors = On/g" /etc/php5/fpm/php.ini
 fi
 
-# Tweak nginx to match the workers to cpu's
-
+# Tweak nginx to match workers to CPUs
 procs=$(cat /proc/cpuinfo |grep processor | wc -l)
 sed -i -e "s/worker_processes 5/worker_processes $procs/" /etc/nginx/nginx.conf
 
@@ -55,8 +53,8 @@ if [[ "$TEMPLATE_NGINX_HTML" == "1" ]] ; then
   done
 fi
 
-# Again set the right permissions (needed when mounting from a volume)
+# Set owner of files (needed when mounting from a volume)
 chown -Rf www-data.www-data /usr/share/nginx/html/
 
-# Start supervisord and services
+# Start supervisord and the services configured therein
 /usr/bin/supervisord -n -c /etc/supervisord.conf


### PR DESCRIPTION
The behaviour of chowning all the website files to www-data.www-data is too violent.  In this pull request this is changed so, by default, only the group is changed to www-data, and the user is left alone.  This way, during development, I can save the PHP files.

The README encourages the user to do `-e SET_USER=www-data` in any environment other than development, though.

I believe this is the best way since setting the user is optional and the sysadmin can even choose the user to whom the files will belong.

Before this I had a different idea (now I consider it less flexible):
https://github.com/nandoflorestan/nginx-php-fpm/commit/33147ca50002c3a20b09a928168221e5abb48a8f