### PR TITLE
Readme should say php7.0 not php5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you have any improvements please submit a pull request.
 The Docker hub build can be found here: [https://registry.hub.docker.com/u/richarvey/nginx-php-fpm/](https://registry.hub.docker.com/u/richarvey/nginx-php-fpm/)
 ## Versions
 - Nginx Mainline Version: **1.9.11**
-- PHP: **5.6**
+- PHP: **7.0**
 - Ubuntu Trusty: **16.04**
 
 ## Building from source


### PR DESCRIPTION
I was looking at the README.md on the 7.0 branch and had to check the source to confirm I was on the correct branch.

I want to fix this for the next reader... I hope this helps