### PR TITLE
Remove the nginx version from the http header

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -16,6 +16,7 @@ events {
 http {
     include       mime.types;
     default_type  application/octet-stream;
+    server_tokens off;
 
     #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
     #                  '$status $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
Improves security: http://serverfault.com/questions/214242/can-i-hide-all-server-os-info/214249