### PR TITLE
Fix wrong port number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To simply run the container:
 sudo docker run -d richarvey/nginx-php-fpm
 ```
 
-You can then browse to ```http://<DOCKER_HOST>:8080``` to view the default install files. To find your ```DOCKER_HOST``` use the ```docker inspect``` to get the IP address.
+You can then browse to ```http://<DOCKER_HOST>``` to view the default install files. To find your ```DOCKER_HOST``` use the ```docker inspect``` to get the IP address.
 
 ### Available Configuration Parameters
 The following flags are a list of all the currently supported options that can be changed by passing in the variables to docker with the -e flag.


### PR DESCRIPTION
There is no port mapping in the given example, and nginx is running on port 80.

See https://github.com/ngineered/nginx-php-fpm/blob/8137d2d0c5e1b9afa36ba2781a027184dc46ad4b/Dockerfile#L115