### PR TITLE
Optimise sed execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,26 +77,30 @@ ADD conf/nginx-site-ssl.conf /etc/nginx/sites-available/default-ssl.conf
 RUN ln -s /etc/nginx/sites-available/default.conf /etc/nginx/sites-enabled/default.conf
 
 # tweak php-fpm config
-RUN sed -i -e "s/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/g" ${php_conf} && \
-sed -i -e "s/upload_max_filesize\s*=\s*2M/upload_max_filesize = 100M/g" ${php_conf} && \
-sed -i -e "s/post_max_size\s*=\s*8M/post_max_size = 100M/g" ${php_conf} && \
-sed -i -e "s/variables_order = \"GPCS\"/variables_order = \"EGPCS\"/g" ${php_conf} && \
-sed -i -e "s/;daemonize\s*=\s*yes/daemonize = no/g" ${fpm_conf} && \
-sed -i -e "s/;catch_workers_output\s*=\s*yes/catch_workers_output = yes/g" ${fpm_conf} && \
-sed -i -e "s/pm.max_children = 4/pm.max_children = 4/g" ${fpm_conf} && \
-sed -i -e "s/pm.start_servers = 2/pm.start_servers = 3/g" ${fpm_conf} && \
-sed -i -e "s/pm.min_spare_servers = 1/pm.min_spare_servers = 2/g" ${fpm_conf} && \
-sed -i -e "s/pm.max_spare_servers = 3/pm.max_spare_servers = 4/g" ${fpm_conf} && \
-sed -i -e "s/pm.max_requests = 500/pm.max_requests = 200/g" ${fpm_conf} && \
-sed -i -e "s/user = nobody/user = nginx/g" ${fpm_conf} && \
-sed -i -e "s/group = nobody/group = nginx/g" ${fpm_conf} && \
-sed -i -e "s/;listen.mode = 0660/listen.mode = 0666/g" ${fpm_conf} && \
-sed -i -e "s/;listen.owner = nobody/listen.owner = nginx/g" ${fpm_conf} && \
-sed -i -e "s/;listen.group = nobody/listen.group = nginx/g" ${fpm_conf} && \
-sed -i -e "s/listen = 127.0.0.1:9000/listen = \/var\/run\/php-fpm.sock/g" ${fpm_conf} &&\
-sed -i -e "s/^;clear_env = no$/clear_env = no/" ${fpm_conf} &&\
-ln -s /etc/php5/php.ini /etc/php5/conf.d/php.ini && \
-find /etc/php5/conf.d/ -name "*.ini" -exec sed -i -re 's/^(\s*)#(.*)/\1;\2/g' {} \;
+RUN sed -i \
+        -e "s/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/g" \
+        -e "s/upload_max_filesize\s*=\s*2M/upload_max_filesize = 100M/g" \
+        -e "s/post_max_size\s*=\s*8M/post_max_size = 100M/g" \
+        -e "s/variables_order = \"GPCS\"/variables_order = \"EGPCS\"/g" \
+        ${php_conf} && \
+    sed -i \
+        -e "s/;daemonize\s*=\s*yes/daemonize = no/g" \
+        -e "s/;catch_workers_output\s*=\s*yes/catch_workers_output = yes/g" \
+        -e "s/pm.max_children = 4/pm.max_children = 4/g" \
+        -e "s/pm.start_servers = 2/pm.start_servers = 3/g" \
+        -e "s/pm.min_spare_servers = 1/pm.min_spare_servers = 2/g" \
+        -e "s/pm.max_spare_servers = 3/pm.max_spare_servers = 4/g" \
+        -e "s/pm.max_requests = 500/pm.max_requests = 200/g" \
+        -e "s/user = nobody/user = nginx/g" \
+        -e "s/group = nobody/group = nginx/g" \
+        -e "s/;listen.mode = 0660/listen.mode = 0666/g" \
+        -e "s/;listen.owner = nobody/listen.owner = nginx/g" \
+        -e "s/;listen.group = nobody/listen.group = nginx/g" \
+        -e "s/listen = 127.0.0.1:9000/listen = \/var\/run\/php-fpm.sock/g" \
+        -e "s/^;clear_env = no$/clear_env = no/" \
+        ${fpm_conf} && \
+    ln -s /etc/php5/php.ini /etc/php5/conf.d/php.ini && \
+    find /etc/php5/conf.d/ -name "*.ini" -exec sed -i -re 's/^(\s*)#(.*)/\1;\2/g' {} \;
 
 # Add Scripts
 ADD scripts/start.sh /start.sh


### PR DESCRIPTION
Call `sed` once per config file instead of once per replacement.