### PR TITLE
Added sassc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN echo @testing http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repo
     gcc \
     musl-dev \
     linux-headers \
+    sassc \
     libffi-dev &&\
     mkdir -p /etc/nginx && \
     mkdir -p /var/www/app && \


### PR DESCRIPTION
Not sure what the decision tree is for adding tools to the image.
1. A lot of tools have been added that take up space and are used only by a niche (letsencrypt).
2. Sassc takes only 1 mb of space (in the final image).

