### PR TITLE
nginx process runs without daemon off.

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -32,7 +32,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:nginx]
-command=/usr/sbin/nginx
+command=/usr/sbin/nginx -g "daemon off;"
 autostart=true
 autorestart=true
 priority=10


### PR DESCRIPTION
nginx process is running without daemon off option in supervisor. so this process is created too many while the system runs.