### PR TITLE
Fix running composer with respect to different WEBROOT.

### DIFF
--- a/docs/repo_layout.md
+++ b/docs/repo_layout.md
@@ -44,6 +44,8 @@ One example would be, if you are running craft CMS you'll end up with a repo str
 
 In this case __WEBROOT__ would be set as __/var/www/html/public__
 
+Note that if you are managing dependencies with composer, your composer.json and composer.lock files should *always* be located in the repo root, not in the directory you set as __WEBROOT__.
+
 ### conf
 This directory is where you can put config files you call from your scripts. It is also home to the nginx folder where you can include custom nginx config files.
 

--- a/scripts/pull
+++ b/scripts/pull
@@ -11,8 +11,8 @@ if [ -z "$GIT_NAME" ]; then
 fi
 
 # Try auto install for composer
-if [ -f "$WEBROOT/composer.lock" ]; then
-  php composer.phar install --no-dev
+if [ -f "/var/www/html/composer.lock" ]; then
+  composer install --no-dev --working-dir=/var/www/html
 fi
 
 cd /var/www/html

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -17,10 +17,7 @@ fi
 
 # Set custom webroot
 if [ ! -z "$WEBROOT" ]; then
- webroot=$WEBROOT
- sed -i "s#root /var/www/html;#root ${webroot};#g" /etc/nginx/sites-available/default.conf
-else
- webroot=/var/www/html
+ sed -i "s#root /var/www/html;#root ${WEBROOT};#g" /etc/nginx/sites-available/default.conf
 fi
 
 # Setup git variables
@@ -62,8 +59,8 @@ if [ ! -d "/var/www/html/.git" ]; then
 fi
 
 # Try auto install for composer
-if [ -f "$WEBROOT/composer.lock" ]; then
-  php composer.phar install --no-dev
+if [ -f "/var/www/html/composer.lock" ]; then
+  composer install --no-dev --working-dir=/var/www/html
 fi
 
 # Enable custom nginx config files if they exist


### PR DESCRIPTION
The composer configuration should always be located in the project root,
independently where the webroot is located. Closes #95.