### PR TITLE
Prevent config files from being filled to infinity

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,6 +3,10 @@
 # Disable Strict Host checking for non interactive git clones
 
 mkdir -p -m 0700 /root/.ssh
+# Prevent config files from being filled to infinity by force of stop and restart the container 
+echo "" > /root/.ssh/config
+/usr/local/etc/php-fpm.conf
+
 echo -e "Host *\n\tStrictHostKeyChecking no\n" >> /root/.ssh/config
 
 if [[ "$GIT_USE_SSH" == "1" ]] ; then
@@ -73,6 +77,13 @@ fi
 
 if [ -f /var/www/html/conf/nginx/nginx-site-ssl.conf ]; then
   cp /var/www/html/conf/nginx/nginx-site-ssl.conf /etc/nginx/sites-available/default-ssl.conf
+fi
+
+
+# Prevent config files from being filled to infinity by force of stop and restart the container
+lastlinephpconf="$(grep "." ./run_example.sh | tail -1)"
+if [[ $lastlinephpconf == *"php_flag[display_errors]"* ]]; then
+ sed '$' /usr/local/etc/php-fpm.conf
 fi
 
 # Display PHP error's or not

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,8 +5,6 @@
 mkdir -p -m 0700 /root/.ssh
 # Prevent config files from being filled to infinity by force of stop and restart the container 
 echo "" > /root/.ssh/config
-/usr/local/etc/php-fpm.conf
-
 echo -e "Host *\n\tStrictHostKeyChecking no\n" >> /root/.ssh/config
 
 if [[ "$GIT_USE_SSH" == "1" ]] ; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -79,9 +79,9 @@ fi
 
 
 # Prevent config files from being filled to infinity by force of stop and restart the container
-lastlinephpconf="$(grep "." ./run_example.sh | tail -1)"
+lastlinephpconf="$(grep "." /usr/local/etc/php-fpm.conf | tail -1)"
 if [[ $lastlinephpconf == *"php_flag[display_errors]"* ]]; then
- sed '$' /usr/local/etc/php-fpm.conf
+ sed -i '$ d' /usr/local/etc/php-fpm.conf
 fi
 
 # Display PHP error's or not


### PR DESCRIPTION
When you start/stop Successively your container, the file /root/.ssh/conf and /usr/local/etc/php-fpm.conf grow to infinity : loop repetition of line "; Include one or more files. If glob(3) exists, it is used to include a bunch of
; files from a glob(3) pattern. This directive can be used everywhere in the
; file.
; Relative path can also be used. They will be prefixed by:
;  - the global prefix if it's been set (-p argument)
;  - /usr/local otherwise
include=etc/php-fpm.d/*.conf
php_flag[display_errors] = off
php_flag[display_errors] = off
php_flag[display_errors] = off
php_flag[display_errors] = off
php_flag[display_errors] = off"