### PR TITLE
Remove unnecessary VOLUME directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -237,8 +237,6 @@ RUN chmod 755 /usr/bin/pull && chmod 755 /usr/bin/push && chmod 755 /usr/bin/let
 ADD src/ /var/www/html/
 ADD errors/ /var/www/errors
 
-VOLUME /var/www/html
-
 EXPOSE 443 80
 
 CMD ["/start.sh"]


### PR DESCRIPTION
As mentioned in https://github.com/ngineered/nginx-php-fpm/issues/139, the `VOLUME` directive is not needed.
If you want to build your app's image based on nginx-php-fpm, you `ADD` the files to `/var/www/html`. When you create a container Docker creates a volume and copies the content of `/var/www/html` to this volume. Then, when you pull an updated version of your app's image and try to recreate the container, the updated files from the new image are not seen because they are hidden by the volume.

I suggest that we remove the `VOLUME` directive. If someone needs it, it can be easily created in docker run arguments, docker-compose 'volumes' or in a child image.